### PR TITLE
ENG-749 Add JIRA-linker plugin

### DIFF
--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//prow/plugins/heart:go_default_library",
         "//prow/plugins/help:go_default_library",
         "//prow/plugins/hold:go_default_library",
+        "//prow/plugins/jira-linker:go_default_library",
         "//prow/plugins/label:go_default_library",
         "//prow/plugins/lgtm:go_default_library",
         "//prow/plugins/lifecycle:go_default_library",

--- a/prow/hook/plugins.go
+++ b/prow/hook/plugins.go
@@ -32,6 +32,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/heart"
 	_ "k8s.io/test-infra/prow/plugins/help"
 	_ "k8s.io/test-infra/prow/plugins/hold"
+	_ "k8s.io/test-infra/prow/plugins/jira-linker"
 	_ "k8s.io/test-infra/prow/plugins/label"
 	_ "k8s.io/test-infra/prow/plugins/lgtm"
 	_ "k8s.io/test-infra/prow/plugins/lifecycle"

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -62,6 +62,7 @@ filegroup(
         "//prow/plugins/heart:all-srcs",
         "//prow/plugins/help:all-srcs",
         "//prow/plugins/hold:all-srcs",
+        "//prow/plugins/jira-linker:all-srcs",
         "//prow/plugins/label:all-srcs",
         "//prow/plugins/lgtm:all-srcs",
         "//prow/plugins/lifecycle:all-srcs",

--- a/prow/plugins/jira-linker/BUILD.bazel
+++ b/prow/plugins/jira-linker/BUILD.bazel
@@ -1,5 +1,19 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
 go_library(
     name = "go_default_library",
     srcs = ["jira-linker.go"],
@@ -23,18 +37,4 @@ go_test(
         "//prow/plugins:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
-)
-
-filegroup(
-    name = "package-srcs",
-    srcs = glob(["**"]),
-    tags = ["automanaged"],
-    visibility = ["//visibility:private"],
-)
-
-filegroup(
-    name = "all-srcs",
-    srcs = [":package-srcs"],
-    tags = ["automanaged"],
-    visibility = ["//visibility:public"],
 )

--- a/prow/plugins/jira-linker/BUILD.bazel
+++ b/prow/plugins/jira-linker/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["jira-linker.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/jira-linker",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["jira-linker_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/plugins/jira-linker/jira-linker.go
+++ b/prow/plugins/jira-linker/jira-linker.go
@@ -1,0 +1,105 @@
+package jira_linker
+
+import (
+	"strings"
+	"regexp"
+	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/github"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	pluginName  = "jira-linker"
+	jiraPrefix  = "jira/"
+	noJiraLabel = jiraPrefix + "no-ticket"
+)
+
+var (
+	jiraRegex       = regexp.MustCompile("([A-Z]+)-\\d+")
+)
+
+type githubClient interface {
+	AddLabel(owner, repo string, number int, label string) error
+	CreateComment(owner, repo string, number int, comment string) error
+	RemoveLabel(owner, repo string, number int, label string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+}
+
+
+func helpProvider(_ *plugins.Configuration, _ []string) (*pluginhelp.PluginHelp, error) {
+	// The Config field is omitted because this plugin is not configurable.
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: "The jira-linker plugin tries to detect JIRA references in PR titles and automatically adds a link to the ticket and a label",
+	}
+	return pluginHelp, nil
+}
+
+func init() {
+	plugins.RegisterPullRequestHandler(pluginName, pullRequestHandler, helpProvider)
+}
+
+func pullRequestHandler(pc plugins.PluginClient, event github.PullRequestEvent) error {
+	return handle(pc.GitHubClient, pc.Logger, pc.PluginConfig.JiraLinker, &event)
+}
+
+func handle(gc githubClient, log *logrus.Entry, config plugins.JiraLinker, event *github.PullRequestEvent) error {
+	org := event.Repo.Owner.Login
+	repo := event.Repo.Name
+
+	labels, err := gc.GetIssueLabels(org, repo, event.Number)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to get the labels on %s/%s#%d.", org, repo, event.Number)
+	}
+
+	matches := jiraRegex.FindStringSubmatch(event.PullRequest.Title)
+	if len(matches) > 1 {
+		ticketName := matches[0]
+		jiraTeamName := matches[1]
+
+		hasLabel := false
+		for _, candidate := range labels {
+			if candidate.Name == noJiraLabel {
+				gc.RemoveLabel(org, repo, event.Number, noJiraLabel)
+			}
+
+			if candidate.Name == jiraLabel(jiraTeamName) {
+				hasLabel = true
+			}
+		}
+
+		if !hasLabel {
+			gc.AddLabel(org, repo, event.Number, jiraLabel(jiraTeamName))
+			gc.CreateComment(org, repo, event.Number, commentForTicket(jiraLink(config.JiraBaseUrl, ticketName)))
+		}
+	} else {
+		hasNoJiraLabel := false
+		for _, candidate := range labels {
+			if candidate.Name != noJiraLabel && strings.HasPrefix(candidate.Name, jiraPrefix) {
+				gc.RemoveLabel(org, repo, event.Number, candidate.Name)
+			}
+
+			if candidate.Name == noJiraLabel {
+				hasNoJiraLabel = true
+			}
+		}
+
+		if !hasNoJiraLabel {
+			gc.AddLabel(org, repo, event.Number, noJiraLabel)
+		}
+	}
+
+	return nil
+}
+
+func jiraLabel(team string) string {
+	return jiraPrefix + team
+}
+
+func commentForTicket(jiraLink string) string {
+	return "Corresponding JIRA ticket: " + jiraLink
+}
+
+func jiraLink(jiraBaseUrl, ticketName string) string {
+	return jiraBaseUrl + "/browse/" + ticketName
+}

--- a/prow/plugins/jira-linker/jira-linker.go
+++ b/prow/plugins/jira-linker/jira-linker.go
@@ -70,8 +70,8 @@ func handle(gc githubClient, log *logrus.Entry, config plugins.JiraLinker, event
 		}
 
 		if !hasLabel {
-			gc.AddLabel(org, repo, event.Number, jiraLabel(jiraTeamName))
 			gc.CreateComment(org, repo, event.Number, commentForTicket(jiraLink(config.JiraBaseUrl, ticketName)))
+			gc.AddLabel(org, repo, event.Number, jiraLabel(jiraTeamName))
 		}
 	} else {
 		hasNoJiraLabel := false

--- a/prow/plugins/jira-linker/jira-linker.go
+++ b/prow/plugins/jira-linker/jira-linker.go
@@ -1,12 +1,14 @@
 package jira_linker
 
 import (
-	"strings"
 	"regexp"
-	"k8s.io/test-infra/prow/plugins"
-	"k8s.io/test-infra/prow/pluginhelp"
-	"k8s.io/test-infra/prow/github"
+	"strings"
+
 	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
 )
 
 const (
@@ -16,7 +18,7 @@ const (
 )
 
 var (
-	jiraRegex       = regexp.MustCompile("([A-Z]+)-\\d+")
+	jiraRegex = regexp.MustCompile("([A-Z]+)-\\d+")
 )
 
 type githubClient interface {
@@ -25,7 +27,6 @@ type githubClient interface {
 	RemoveLabel(owner, repo string, number int, label string) error
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 }
-
 
 func helpProvider(_ *plugins.Configuration, _ []string) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.

--- a/prow/plugins/jira-linker/jira-linker_test.go
+++ b/prow/plugins/jira-linker/jira-linker_test.go
@@ -71,6 +71,13 @@ func TestJiraLink(t *testing.T) {
 			labelsAddedOverall: []string{jiraPrefix + "TEST"},
 			shouldComment:      false,
 		},
+		{
+			name:               "two tickets in the title",
+			title:              "TEST-32 fix every bug and fixes TEST-303",
+			hasLabels:          []string{jiraPrefix + "TEST"},
+			labelsAddedOverall: []string{jiraPrefix + "TEST"},
+			shouldComment:      false,
+		},
 	} {
 		fc := &fakegithub.FakeClient{
 			IssueComments: make(map[int][]github.IssueComment),

--- a/prow/plugins/jira-linker/jira-linker_test.go
+++ b/prow/plugins/jira-linker/jira-linker_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jira_linker
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+func TestJiraLink(t *testing.T) {
+	const jiraBaseUrl = "http://example.com/jira"
+
+	repoLabelCommentPrefix := "org/repo#5:"
+
+	for _, tc := range []struct {
+		name                 string
+		title                string
+		hasLabels            []string
+		labelsAddedOverall   []string
+		labelsRemovedOverall []string
+		shouldComment        bool
+		comment              string
+	}{
+		{
+			name:               "non-jira PR",
+			title:              "add sauce to spaghetti",
+			hasLabels:          []string{},
+			labelsAddedOverall: []string{noJiraLabel},
+			shouldComment:      false,
+		},
+		{
+			name:               "basic jira PR",
+			title:              "TEST-43 add sauce to spaghetti",
+			hasLabels:          []string{},
+			labelsAddedOverall: []string{jiraPrefix + "TEST"},
+			shouldComment:      true,
+			comment:            commentForTicket(jiraLink(jiraBaseUrl, "TEST-43")),
+		},
+		{
+			name:                 "starts with wrong labels",
+			title:                "TEST-32 fix every bug",
+			hasLabels:            []string{noJiraLabel},
+			labelsAddedOverall:   []string{noJiraLabel, jiraPrefix + "TEST"},
+			labelsRemovedOverall: []string{noJiraLabel},
+			shouldComment:        true,
+			comment:              commentForTicket(jiraLink(jiraBaseUrl, "TEST-32")),
+		},
+		{
+			name:               "starts with right labels",
+			title:              "TEST-32 fix every bug",
+			hasLabels:          []string{jiraPrefix + "TEST"},
+			labelsAddedOverall: []string{jiraPrefix + "TEST"},
+			shouldComment:      false,
+		},
+	} {
+		fc := &fakegithub.FakeClient{
+			IssueComments: make(map[int][]github.IssueComment),
+		}
+		e := &github.PullRequestEvent{
+			Action: github.PullRequestActionEdited,
+			PullRequest: github.PullRequest{
+				Title: tc.title,
+			},
+			Number: 5,
+			Repo:   github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+		}
+
+		fc.LabelsAdded = []string{}
+		for _, label := range tc.hasLabels {
+			fc.LabelsAdded = append(fc.LabelsAdded, repoLabelCommentPrefix+label)
+		}
+		t.Logf("BEFORE\nAdded: %+v,\nRemoved: %+v\nAll: %+v", fc.LabelsAdded, fc.LabelsRemoved, fc.ExistingLabels)
+
+		err := handle(fc, logrus.WithField("plugin", pluginName), plugins.JiraLinker{JiraBaseUrl: jiraBaseUrl}, e)
+		if err != nil {
+			t.Errorf("For case %s, didn't expect error: %v", tc.name, err)
+			continue
+		}
+
+		t.Logf("AFTER\nAdded: %+v,\nRemoved: %+v\nAll: %+v", fc.LabelsAdded, fc.LabelsRemoved, fc.ExistingLabels)
+
+		if len(fc.LabelsRemoved) != len(tc.labelsRemovedOverall) {
+			t.Errorf("Unexpected labels removed for case %s (got %+v, expected %+v)", tc.name, fc.LabelsRemoved, tc.labelsRemovedOverall)
+		} else {
+			for i, label := range fc.LabelsRemoved {
+				if repoLabelCommentPrefix+tc.labelsRemovedOverall[i] != label {
+					t.Errorf("Unexpected labels removed for case %s (got %+v, expected %+v)", tc.name, fc.LabelsRemoved, tc.labelsRemovedOverall)
+				}
+			}
+		}
+
+		if len(fc.LabelsAdded) != len(tc.labelsAddedOverall) {
+			t.Errorf("Unexpected labels added for case %s (got %+v, expected %+v)", tc.name, fc.LabelsAdded, tc.labelsAddedOverall)
+		} else {
+			for i, label := range fc.LabelsAdded {
+				if repoLabelCommentPrefix+tc.labelsAddedOverall[i] != label {
+					t.Errorf("Unexpected labels added for case %s (got %+v, expected %+v)", tc.name, fc.LabelsAdded, tc.labelsAddedOverall)
+				}
+			}
+		}
+
+		if tc.shouldComment {
+			if len(fc.IssueCommentsAdded) == 1 {
+				if fc.IssueCommentsAdded[0] != repoLabelCommentPrefix+tc.comment {
+					t.Errorf("Unexpected comment added for case %s - expected \"%s\" but got \"%s\"", tc.name, tc.comment, fc.IssueCommentsAdded[0])
+				}
+			} else {
+				t.Errorf("Expected issue comment for case %s but none / too many were added", tc.name)
+			}
+		} else if len(fc.IssueCommentsAdded) > 0 {
+			t.Errorf("Issue comment added unexpectedly for case %s (comments[0]: %s)", tc.name, fc.IssueCommentsAdded[0])
+		}
+	}
+}

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -176,6 +176,7 @@ type Configuration struct {
 	Size          *Size                `json:"size,omitempty"`
 	Triggers      []Trigger            `json:"triggers,omitempty"`
 	Welcome       Welcome              `json:"welcome,omitempty"`
+	JiraLinker    JiraLinker           `json:"jira_linker,omitempty"`
 }
 
 // ExternalPlugin holds configuration for registering an external
@@ -457,6 +458,11 @@ type Welcome struct {
 	// For the info struct see prow/plugins/welcome/welcome.go's PRInfo
 	// TODO(bentheelder): make this be configurable per-repo?
 	MessageTemplate string `json:"message_template,omitempty"`
+}
+
+// JiraLinker is the config for the jira-linker plugin
+type JiraLinker struct {
+	JiraBaseUrl string `json:"jira_base_url"`
 }
 
 // TriggerFor finds the Trigger for a repo, if one exists


### PR DESCRIPTION
## Summary

Adds a plugin, `jira-linker`, which should add some comments and labels to PRs

## How to verify

The unit tests cover most behaviour I could imagine, so `bazel test //prow/plugins/jira-linker` should be sufficient.

I'll do a supervised run in `platform` after merging while it's quiet. I don't think the risk of adding this is high since it only acts with a few relatively harmless API calls such as adding/removing labels and it will only be invoked by specific new events.