### PR TITLE
Implement custom OWNERS assignment prevention behaviour

### DIFF
--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -39,7 +39,7 @@ const (
 var (
 	autoAssignRe    = regexp.MustCompile(`(?mi)^/assign-reviewers$`)
 	noAutoAssignRe  = regexp.MustCompile(`(?mi)^/no-assign-reviewers$`)
-	noAssignTitleRe = regexp.MustCompile(`(?i)^\W?WIP\W`)
+	noAssignTitleRe = regexp.MustCompile(`(?i)(^\W?WIP\b|\[WIP\]|\(WIP\))`)
 )
 
 func init() {


### PR DESCRIPTION
Based on internal discussions and feedback from a number of internal customers, it seems like we need to make some changes to how Blunderbuss (OWNERS assignment) decides who to assign.

As it will likely be difficult to come up with a good more permanent solution to the issues we're having, in the mean-time I have made some stop-gap changes which should mitigate some of the biggest issues people are having.

We have no current plans to try upstreaming this (based on discussion, we should decide on an approach to suggest and then set up a design doc with them), however it would be nice to see if they would be receptive to the `wip` functionality put behind a flag at some point.