### PR TITLE
ENG-823: Allow JIRA-linker to detect tickets in the branch name

### DIFF
--- a/prow/plugins/jira-linker/jira-linker.go
+++ b/prow/plugins/jira-linker/jira-linker.go
@@ -18,8 +18,9 @@ const (
 )
 
 var (
-	jiraRegex     = regexp.MustCompile("([A-Z]+)-\\d+")
-	enabledEvents = []github.PullRequestEventAction{
+	jiraTitleRegex  = regexp.MustCompile("([A-Z]+)-\\d+")
+	jiraBranchRegex = regexp.MustCompile("^\\w+/(([A-Z]+)-\\d+)(-|$)")
+	enabledEvents   = []github.PullRequestEventAction{
 		github.PullRequestActionOpened,
 		github.PullRequestActionEdited,
 		github.PullRequestActionReopened,
@@ -71,11 +72,9 @@ func handle(gc githubClient, log *logrus.Entry, config plugins.JiraLinker, event
 		log.WithError(err).Errorf("Failed to get the labels on %s/%s#%d.", org, repo, event.Number)
 	}
 
-	matches := jiraRegex.FindStringSubmatch(event.PullRequest.Title)
-	if len(matches) > 1 {
-		ticketName := matches[0]
-		jiraTeamName := matches[1]
 
+	found, jiraTeamName, ticketName := extractJiraTicketDetails(event.PullRequest.Title, event.PullRequest.Head.Ref)
+	if found {
 		hasLabel := false
 		for _, candidate := range labels {
 			if candidate.Name == noJiraLabel {
@@ -109,6 +108,20 @@ func handle(gc githubClient, log *logrus.Entry, config plugins.JiraLinker, event
 	}
 
 	return nil
+}
+
+// Returns if found, and if so respectively the ticket type (e.g. ENG) and the ticket ref (e.g. ENG-23)
+func extractJiraTicketDetails(title, ref string) (bool, string, string) {
+	matches := jiraTitleRegex.FindStringSubmatch(title)
+	if len(matches) > 0 {
+		return true, matches[1], matches[0]
+	}
+	matches = jiraBranchRegex.FindStringSubmatch(ref)
+	if len(matches) > 0 {
+		return true, matches[2], matches[1]
+	}
+
+	return false, "", ""
 }
 
 func jiraLabel(team string) string {

--- a/prow/plugins/jira-linker/jira-linker.go
+++ b/prow/plugins/jira-linker/jira-linker.go
@@ -111,7 +111,7 @@ func handle(gc githubClient, log *logrus.Entry, config plugins.JiraLinker, event
 }
 
 // Returns if found, and if so respectively the ticket type (e.g. ENG) and the ticket ref (e.g. ENG-23)
-func extractJiraTicketDetails(title, ref string) (bool, string, string) {
+func extractJiraTicketDetails(title string, ref string) (bool, string, string) {
 	matches := jiraTitleRegex.FindStringSubmatch(title)
 	if len(matches) > 0 {
 		return true, matches[1], matches[0]

--- a/prow/plugins/jira-linker/jira-linker.go
+++ b/prow/plugins/jira-linker/jira-linker.go
@@ -19,7 +19,7 @@ const (
 
 var (
 	jiraTitleRegex  = regexp.MustCompile("([A-Z]+)-\\d+")
-	jiraBranchRegex = regexp.MustCompile("^\\w+/(([A-Z]+)-\\d+)(-|$)")
+	jiraBranchRegex = regexp.MustCompile("^\\w+/(([A-Za-z]+)-\\d+)(-|$|_)")
 	enabledEvents   = []github.PullRequestEventAction{
 		github.PullRequestActionOpened,
 		github.PullRequestActionEdited,
@@ -118,7 +118,7 @@ func extractJiraTicketDetails(title, ref string) (bool, string, string) {
 	}
 	matches = jiraBranchRegex.FindStringSubmatch(ref)
 	if len(matches) > 0 {
-		return true, matches[2], matches[1]
+		return true, strings.ToUpper(matches[2]), strings.ToUpper(matches[1])
 	}
 
 	return false, "", ""

--- a/prow/plugins/jira-linker/jira-linker_test.go
+++ b/prow/plugins/jira-linker/jira-linker_test.go
@@ -164,7 +164,7 @@ func TestJiraTicketRef(t *testing.T) {
 		{
 			// Title tickets should be higher priority than branches
 			prTitle:     "WIP JIRA-43 charge extra for condiments",
-			prBranch:    "feature/ENG-32-delete-everything",
+			prBranch:    "feature/eng-32-delete-everything",
 			shouldFind:  true,
 			ticketTitle: "JIRA-43",
 			ticketTeam:  "JIRA",

--- a/prow/plugins/jira-linker/jira-linker_test.go
+++ b/prow/plugins/jira-linker/jira-linker_test.go
@@ -138,3 +138,52 @@ func TestJiraLink(t *testing.T) {
 		}
 	}
 }
+
+func TestJiraTicketRef(t *testing.T) {
+	for _, test := range []struct{
+		prTitle string
+		prBranch string
+		shouldFind bool
+		ticketTitle string
+		ticketTeam string
+	}{
+		{
+			prTitle:     "ENG-32: Swap colour to color",
+			prBranch:    "random branch name",
+			shouldFind:  true,
+			ticketTitle: "ENG-32",
+			ticketTeam:  "ENG",
+		},
+		{
+			prTitle:     "random ticket title",
+			prBranch:    "feature/ENG-32-stand-on-the-left",
+			shouldFind:  true,
+			ticketTitle: "ENG-32",
+			ticketTeam:  "ENG",
+		},
+		{
+			// Title tickets should be higher priority than branches
+			prTitle:     "WIP JIRA-43 charge extra for condiments",
+			prBranch:    "feature/ENG-32-delete-everything",
+			shouldFind:  true,
+			ticketTitle: "JIRA-43",
+			ticketTeam:  "JIRA",
+		},
+		{
+			prTitle:     "test",
+			prBranch:    "TEST-23-test",
+			shouldFind:  false,
+		},
+	}{
+		found, team, ticket := extractJiraTicketDetails(test.prTitle, test.prBranch)
+		if found != test.shouldFind {
+			t.Errorf("Unexpected result for test %+v", test)
+		}
+		if team != test.ticketTeam {
+			t.Errorf("Unexpected result for test %+v (got %s, expected %s)", test, team, test.ticketTeam)
+		}
+		if ticket != test.ticketTitle {
+			t.Errorf("Unexpected result for test %+v (got %s, expected %s)", test, ticket, test.ticketTitle)
+		}
+	}
+}


### PR DESCRIPTION
This PR expands JIRA-linker to allow it to identify tickets in the branch name given our most common convention for that.

/cc @improbable-nickkrempel @andrew-improbable @petemounce @DoomGerbil @efarem 