### PR TITLE
ENG-615: Update Prow CI

### DIFF
--- a/.buildkite/premerge.definition.yaml
+++ b/.buildkite/premerge.definition.yaml
@@ -1,11 +1,7 @@
-agent_queue_id: v-81e791d9b1a186e5-------1531323149
+agent_queue_id: v-c3aa0727f94b044d-------1537468604
 description: Premerge testing for Prow
 github:
-  branch_configuration:
-  - "*"
   default_branch: master
-  pull_request_branch_filter_configuration:
-  - "*"
 teams:
 - name: infra/ev
   permission: MANAGE_BUILD_AND_READ

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -7,7 +7,7 @@
 # You may find the example pipeline steps listed here helpful: https://buildkite.com/docs/pipelines/defining-steps#example-pipeline but please
 #  note that the setup is already done, so you should not manually adjust anything through the BuildKite interface.
 #
-agent_queue: &agent_queue "queue=v-1d8f8fb001930488-------1536585179"
+agent_queue: &agent_queue "queue=v-c3aa0727f94b044d-------1537468604"
 steps:
   - label: "Prow Unit Tests"
     command: ".buildkite/run_prow_tests.sh"


### PR DESCRIPTION
Updates the CI to use the new agent queue, and remove some pointless parts of the definition file. This PR is running on the new pipeline, so if it passes then everything is fine.