### PR TITLE
WRK-677 - Add an HTTP endpoint to RepoOwners for platform calls

### DIFF
--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -218,6 +218,9 @@ func main() {
 	http.Handle("/hook", server)
 	// Serve plugin help information from /plugin-help.
 	http.Handle("/plugin-help", pluginhelp.NewHelpAgent(pluginAgent, githubClient))
+	// Improbable: add our own repo-owner endpoint handler.
+	http.Handle("/owners", &repoowners.OwnersServer{OwnersClient: ownersClient})
+	// end-of-Improbable: add our own repo-owner endpoint handler
 
 	httpServer := &http.Server{Addr: ":" + strconv.Itoa(o.port)}
 

--- a/prow/repoowners/BUILD.bazel
+++ b/prow/repoowners/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["repoowners.go"],
+    srcs = [
+        "repoowners.go",
+        "endpoint.go",
+        ],
     importpath = "k8s.io/test-infra/prow/repoowners",
     visibility = ["//visibility:public"],
     deps = [
@@ -17,7 +20,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["repoowners_test.go"],
+    srcs = [
+        "repoowners_test.go",
+        "endpoint_test.go",
+        ],
     embed = [":go_default_library"],
     deps = [
         "//prow/config:go_default_library",

--- a/prow/repoowners/endpoint.go
+++ b/prow/repoowners/endpoint.go
@@ -1,0 +1,124 @@
+package repoowners
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type OwnersServer struct {
+	OwnersClient *Client
+}
+
+type ownersRequest struct {
+	Org        string   `json:"org_name"`
+	Repo       string   `json:"repo_name"`
+	BaseCommit string   `json:"base_commit"`
+	Paths      []string `json:"file_paths"`
+}
+
+type httpJSONError struct {
+	Message string `json:"error_message"`
+}
+
+type ownersResponse struct {
+	ConfigMap map[string]*Config `json:"owners,omitempty"`
+}
+
+const (
+	contentTypeJSON = "This JSON-API require a JSON content-type"
+	emptyBody       = "The body is empty, there is no content to parse"
+	emptyPath       = "Path(s) list is empty or non-existing"
+	nonPossibleRepo = "The Org or repo or BaseCommit may be not valid(s)"
+	corruptedBody   = "The body seems to be corrupted"
+	corruptedJSON   = "The JSON seems to be corrupted"
+)
+
+func generateMessage(message string) []byte {
+	result, err := json.Marshal(httpJSONError{Message: message})
+	if err != nil {
+		result = []byte(fmt.Sprintf("failed to marshal error: %v", err))
+	}
+	return result
+}
+
+func generateErrorMessage(err error, message string) []byte {
+	return generateMessage(fmt.Sprintf("%v : %v", message, err))
+}
+
+func (s *OwnersServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Header.Get("Content-Type") != "application/json" {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write(generateMessage(contentTypeJSON))
+		return
+	}
+
+	rawBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write(generateErrorMessage(err, corruptedBody))
+		return
+	} else if len(rawBody) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write(generateMessage(emptyBody))
+		return
+	}
+
+	reqBody := &ownersRequest{}
+	if err = json.Unmarshal(rawBody, reqBody); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write(generateErrorMessage(err, corruptedJSON))
+		return
+	}
+	if len(reqBody.Paths) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write(generateMessage(emptyPath))
+		return
+	}
+
+	ownerIfc, err := s.OwnersClient.LoadRepoOwners(reqBody.Org, reqBody.Repo, reqBody.BaseCommit)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write(generateErrorMessage(err, nonPossibleRepo))
+		return
+	}
+
+	requestedOwners := &ownersResponse{ConfigMap: map[string]*Config{}}
+	for _, path := range reqBody.Paths {
+		var approvers []string
+		if len(ownerIfc.Approvers(path)) > 0 {
+			approvers = ownerIfc.Approvers(path).List()
+		}
+		var requiredReviewers []string
+		if len(ownerIfc.RequiredReviewers(path)) > 0 {
+			requiredReviewers = ownerIfc.RequiredReviewers(path).List()
+		}
+		var reviewers []string
+		if len(ownerIfc.Reviewers(path)) > 0 {
+			reviewers = ownerIfc.Reviewers(path).List()
+		}
+		var labels []string
+		if len(ownerIfc.FindLabelsForFile(path)) > 0 {
+			labels = ownerIfc.FindLabelsForFile(path).List()
+		}
+
+		requestedOwners.ConfigMap[path] = &Config{
+			Approvers:         approvers,
+			RequiredReviewers: requiredReviewers,
+			Reviewers:         reviewers,
+			Labels:            labels,
+		}
+	}
+
+	rawResultBody, err := json.Marshal(requestedOwners.ConfigMap)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write(generateMessage(corruptedJSON))
+	} else {
+		w.WriteHeader(http.StatusOK)
+		w.Write(rawResultBody)
+	}
+}

--- a/prow/repoowners/endpoint_test.go
+++ b/prow/repoowners/endpoint_test.go
@@ -1,0 +1,276 @@
+package repoowners
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+)
+
+// TestEndpointSuccess tests the handling of normal input by the owners endpoint.
+func TestEndpointSuccess(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         *ownersRequest
+		contentType  string
+		expectedBody string
+		expectedCode int
+	}{
+		{
+			name: "general use case",
+			body: &ownersRequest{
+				Org:        "org",
+				Repo:       "repo",
+				BaseCommit: "master",
+				Paths: []string{
+					"src/dir",
+					"src",
+					"foo",
+					"src/dir/conformance",
+					"docs",
+					"docs/file.md",
+				},
+			},
+			contentType:  "application/json",
+			expectedBody: `{"docs":{"approvers":["cjwagner"],"reviewers":["alice","bob"],"required_reviewers":["chris"],"labels":["EVERYTHING"]},"docs/file.md":{"approvers":["alice","cjwagner"],"reviewers":["alice","bob"],"required_reviewers":["chris"],"labels":["EVERYTHING","docs"]},"foo":{"approvers":["cjwagner"],"reviewers":["alice","bob"],"required_reviewers":["chris"],"labels":["EVERYTHING"]},"src":{"approvers":["carl","cjwagner"],"reviewers":["alice","bob"],"required_reviewers":["chris"],"labels":["EVERYTHING"]},"src/dir":{"approvers":["bob","carl","cjwagner"],"reviewers":["alice","bob","cjwagner"],"required_reviewers":["ben","chris"],"labels":["EVERYTHING","src-code"]},"src/dir/conformance":{"approvers":["mml"]}}`,
+			expectedCode: http.StatusOK,
+		},
+		{
+			name: "Missing content-type information",
+			body: &ownersRequest{
+				Org:        "org",
+				Repo:       "repo",
+				BaseCommit: "master",
+				Paths: []string{
+					"src/dir",
+					"src",
+					"foo",
+					"src/dir/conformance",
+					"docs",
+					"docs/file.md",
+				},
+			},
+			contentType:  "",
+			expectedBody: `{"error_message":"This JSON-API require a JSON content-type"}`,
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "Empty paths",
+			body: &ownersRequest{
+				Org:        "org",
+				Repo:       "repo",
+				BaseCommit: "master",
+				Paths:      []string{},
+			},
+			contentType:  "application/json",
+			expectedBody: `{"error_message":"Path(s) list is empty or non-existing"}`,
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "Empty body",
+			body:         nil,
+			contentType:  "application/json",
+			expectedBody: `{"error_message":"Path(s) list is empty or non-existing"}`,
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "Non-valid basecommit",
+			body: &ownersRequest{
+				Org:        "org",
+				Repo:       "repo",
+				BaseCommit: "13202CD5-3068-46D4-8C1D-46F544ED39EF",
+				Paths: []string{
+					"src/dir",
+					"src",
+					"foo",
+					"src/dir/conformance",
+					"docs",
+					"docs/file.md",
+				},
+			},
+			contentType:  "application/json",
+			expectedBody: `{"error_message":"The Org or repo or BaseCommit may be not valid(s) : error checking out 13202CD5-3068-46D4-8C1D-46F544ED39EF: exit status 1. output: error: pathspec '13202CD5-3068-46D4-8C1D-46F544ED39EF' did not match any file(s) known to git\n"}`,
+			expectedCode: http.StatusBadRequest,
+		},
+	}
+
+	client, cleanup, initErr := getTestClient(testFiles, true, false, true, nil, nil, nil)
+	switch {
+	case initErr != nil:
+		t.Fatalf("Error creating test client: %v.", initErr)
+	case client == nil:
+		t.Fatalf("Fake client could not be instantiated.")
+	case cleanup == nil:
+		t.Fatalf("Fake client cleaner could not be instantiated.")
+	}
+	defer cleanup()
+
+	ownersServer := &OwnersServer{OwnersClient: client}
+
+	for _, test := range tests {
+		t.Logf("Running scenario %q", test.name)
+
+		rawBody, err := json.Marshal(test.body)
+		if err != nil {
+			t.Fatalf("Ill-formed testing input %v.", err)
+		}
+
+		req, err := http.NewRequest("POST", "/", bytes.NewBuffer(rawBody))
+		if err != nil {
+			t.Fatalf("POST query to the EndPoint failed : %v.", err)
+		}
+		req.Header.Set("Content-Type", test.contentType)
+
+		rr := httptest.NewRecorder()
+		ownersServer.ServeHTTP(rr, req)
+		if rr.Code != test.expectedCode {
+			t.Errorf("Handler returned wrong status code: got %v want %v", rr.Code, test.expectedCode)
+		}
+		if rr.Body.String() != test.expectedBody {
+			t.Errorf("Handler returned unexpected body: got %v want %v", rr.Body.String(), test.expectedBody)
+		}
+	}
+}
+
+// TestEndPointRegex tests the handling of edge-cases inputs by the owners endpoint which need regex.
+// We have to use regex regarding the fact we are grounded on RepoOwners error that can contain random-based path
+func TestEndPointRegex(t *testing.T) {
+	tests := []struct {
+		name              string
+		body              *ownersRequest
+		contentType       string
+		expectedBodyRegex string
+		expectedCode      int
+	}{
+		{
+			name: "Non-valid org",
+			body: &ownersRequest{
+				Org:        "9AA48AEB-30EB-4187-89E7-5FAEACC3EC91",
+				Repo:       "repo",
+				BaseCommit: "master",
+				Paths: []string{
+					"src/dir",
+					"src",
+					"foo",
+					"src/dir/conformance",
+					"docs",
+					"docs/file.md",
+				},
+			},
+			contentType:       "application/json",
+			expectedBodyRegex: `^{"error_message":"The Org or repo or BaseCommit may be not valid\(s\) : failed to clone 9AA48AEB-30EB-4187-89E7-5FAEACC3EC91\/repo: git cache clone error: exit status 128\. output: fatal: repository .* does not exist\\n"}$`,
+			expectedCode:      http.StatusBadRequest,
+		},
+		{
+			name: "Non-valid repo",
+			body: &ownersRequest{
+				Org:        "org",
+				Repo:       "A1A1693C-082C-41B1-9943-3A89B08A57C0",
+				BaseCommit: "Master",
+				Paths: []string{
+					"src/dir",
+					"src",
+					"foo",
+					"src/dir/conformance",
+					"docs",
+					"docs/file.md",
+				},
+			},
+			contentType:       "application/json",
+			expectedBodyRegex: `^{"error_message":"The Org or repo or BaseCommit may be not valid\(s\) : failed to clone org\/A1A1693C-082C-41B1-9943-3A89B08A57C0: git cache clone error: exit status 128\. output: fatal: repository .* does not exist\\n"}$`,
+			expectedCode:      http.StatusBadRequest,
+		},
+	}
+
+	client, cleanup, initErr := getTestClient(testFiles, true, false, true, nil, nil, nil)
+	switch {
+	case initErr != nil:
+		t.Fatalf("Error creating test client: %v.", initErr)
+	case client == nil:
+		t.Fatalf("Fake client could not be instantiated.")
+	case cleanup == nil:
+		t.Fatalf("Fake client cleaner could not be instantiated.")
+	}
+	defer cleanup()
+
+	ownersServer := &OwnersServer{OwnersClient: client}
+
+	for _, test := range tests {
+		t.Logf("Running scenario %q", test.name)
+
+		rawBody, err := json.Marshal(test.body)
+		if err != nil {
+			t.Fatalf("Ill-formed testing input %v.", err)
+		}
+
+		req, err := http.NewRequest("POST", "/", bytes.NewBuffer(rawBody))
+		if err != nil {
+			t.Fatalf("POST query to the EndPoint failed : %v.", err)
+		}
+		req.Header.Set("Content-Type", test.contentType)
+
+		rr := httptest.NewRecorder()
+		ownersServer.ServeHTTP(rr, req)
+		if rr.Code != test.expectedCode {
+			t.Errorf("Handler returned wrong status code: got %v want %v", rr.Code, test.expectedCode)
+		}
+		matched, err := regexp.MatchString(test.expectedBodyRegex, rr.Body.String())
+		if matched != true {
+			t.Errorf("Handler returned unexpected body: got %v want to match regex(%v)", rr.Body.String(), test.expectedBodyRegex)
+		}
+	}
+}
+
+// TestEndpointCorrupted tests the handling of corrupted messages by the owners endpoint.
+func TestEndpointCorrupted(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         []byte
+		contentType  string
+		expectedBody string
+		expectedCode int
+	}{
+		{
+			name:         "Empty body",
+			body:         []byte(""),
+			contentType:  "application/json",
+			expectedBody: `{"error_message":"The body is empty, there is no content to parse"}`,
+			expectedCode: http.StatusBadRequest,
+		},
+	}
+
+	client, cleanup, initErr := getTestClient(testFiles, true, false, true, nil, nil, nil)
+	switch {
+	case initErr != nil:
+		t.Fatalf("Error creating test client: %v.", initErr)
+	case client == nil:
+		t.Fatalf("Fake client could not be instantiated.")
+	case cleanup == nil:
+		t.Fatalf("Fake client cleaner could not be instantiated.")
+	}
+	defer cleanup()
+
+	ownersServer := &OwnersServer{OwnersClient: client}
+
+	for _, test := range tests {
+		t.Logf("Running scenario %q", test.name)
+
+		req, err := http.NewRequest("POST", "/", bytes.NewBuffer(test.body))
+		if err != nil {
+			t.Fatalf("POST query to the EndPoint failed : %v.", err)
+		}
+		req.Header.Set("Content-Type", test.contentType)
+
+		rr := httptest.NewRecorder()
+
+		ownersServer.ServeHTTP(rr, req)
+		if rr.Code != test.expectedCode {
+			t.Errorf("handler returned wrong status code: got %v want %v", rr.Code, test.expectedCode)
+		}
+		if rr.Body.String() != test.expectedBody {
+			t.Errorf("handler returned unexpected body: got %v want %v", rr.Body.String(), test.expectedBody)
+		}
+	}
+}


### PR DESCRIPTION
Following the discussion on the following [ticket](https://improbableio.atlassian.net/browse/WRK-677), we needed a way to retrieve in a consistent way the OWNERS of a given file for the Cascader rule