### PR TITLE
ENG-1281: trigger.sh is no longer necessary.

### DIFF
--- a/.buildkite/trigger.sh
+++ b/.buildkite/trigger.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-if [[ -n "${DEBUG-}" ]]; then
-  set -x
-fi
-cd "$(dirname "$0")/../"
-
-buildkite-agent pipeline upload "$1"


### PR DESCRIPTION
ENG-1281 replaces trigger.sh with `imp-ci steps run --from ...steps.yaml`.

If, after this deletion, your pipeline fails to run, you should:

```bash
cd {repo-root}
circle ci pipeline push -n {name}
```

and `rebuild`, because (apologies) I must have missed it when I bulk-updated pipelines in BuildKite.

The pipeline definition _within the buildkite pipeline settings page_ should resemble:

```yaml
steps:
- agents:
  - environment=production
  - queue=trigger-pipelines
  command: imp-ci steps run --from .buildkite/premerge.steps.yaml
  label: premerge
  retry:
    automatic:
    - exit_status: -1
      limit: 3
  timeout_in_minutes: 10
- wait: wait-for-steps-upload
```

The two differences that my change makes are
* ENG-1281: the change to the command step from `.buildkite/trigger.sh {name}.steps.yaml` to `imp-ci steps run --from {name}.steps.yaml`
* ENG-1450: the addition of the `- wait: wait-for-steps-upload` _after_ the `command` step (to eliminate a race condition when cancelling a pipeline).