### PR TITLE
Fix jira-linker and internal build script

### DIFF
--- a/hack/improbapublish.sh
+++ b/hack/improbapublish.sh
@@ -5,9 +5,23 @@
 ###
 
 export PROW_REPO_OVERRIDE="eu.gcr.io/windy-oxide-102215"
-export DOCKER_REPO_OVERRIDE="eu.gcr.io/windy-oxide-102215"
+export DOCKER_REPO_OVERRIDE="${PROW_REPO_OVERRIDE}"
+export EDGE_PROW_REPO_OVERRIDE="${PROW_REPO_OVERRIDE}"
 
-# bazel run //prow:release-push-hook --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
-bazel run \
+# By default, try to use Bazelisk, since this repo doesn't have `tools/bazel` set up.
+# If that fails, try just `bazel`, and if that fails, just bail out.
+echo "Attempting to run script with Bazelisk first."
+BAZEL_BIN="bazelisk"
+command -v "${BAZEL_BIN}" >"/dev/null"
+if [[ $? != 0 ]]; then
+  BAZEL_BIN="bazel"
+  echo "Bazelisk not found, attempting to use 'bazel' directly"
+  command -v "${BAZEL_BIN}" >"/dev/null" || (echo "Bazel not found - install it to build this tool." && exit 1)
+fi
+
+echo "BAZEL_BIN is set to ${BAZEL_BIN}"
+
+
+"${BAZEL_BIN}" run \
   --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
   //prow:improbable-push

--- a/hack/improbapublish.sh
+++ b/hack/improbapublish.sh
@@ -10,17 +10,20 @@ export EDGE_PROW_REPO_OVERRIDE="${PROW_REPO_OVERRIDE}"
 
 # By default, try to use Bazelisk, since this repo doesn't have `tools/bazel` set up.
 # If that fails, try just `bazel`, and if that fails, just bail out.
-echo "Attempting to run script with Bazelisk first."
 BAZEL_BIN="bazelisk"
 command -v "${BAZEL_BIN}" >"/dev/null"
 if [[ $? != 0 ]]; then
   BAZEL_BIN="bazel"
-  echo "Bazelisk not found, attempting to use 'bazel' directly"
-  command -v "${BAZEL_BIN}" >"/dev/null" || (echo "Bazel not found - install it to build this tool." && exit 1)
+  echo "WARNING: Bazelisk not found, attempting to use 'bazel' directly."
+  echo "Without bazelisk installed, you may need to manually install the correct Bazel version."
+  command -v "${BAZEL_BIN}" >"/dev/null"
+  if [[ $? != 0 ]]; then
+    echo "Bazel not found - install it to build this tool."
+    exit 1
+  fi
 fi
 
-echo "BAZEL_BIN is set to ${BAZEL_BIN}"
-
+echo "Using ${BAZEL_BIN} as Bazel."
 
 "${BAZEL_BIN}" run \
   --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -13,10 +13,9 @@ container_bundle(
     stamp = True,
 )
 
-container_push(
+docker_push(
     name = "release-push-deck",
     bundle = ":release-deck",
-    format = "OCI",
 )
 
 container_bundle(
@@ -28,10 +27,9 @@ container_bundle(
     stamp = True,
 )
 
-container_push(
+docker_push(
     name = "release-push-hook",
     bundle = ":release-hook",
-    format = "OCI",
 )
 
 container_bundle(
@@ -43,10 +41,9 @@ container_bundle(
     stamp = True,
 )
 
-container_push(
+docker_push(
     name = "release-push-tide",
     bundle = ":release-tide",
-    format = "OCI",
 )
 
 prow_push(

--- a/prow/plugins/jira-linker/BUILD.bazel
+++ b/prow/plugins/jira-linker/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/jira-linker",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
@@ -32,6 +33,7 @@ go_test(
     srcs = ["jira-linker_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/jira-linker/jira-linker.go
+++ b/prow/plugins/jira-linker/jira-linker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -34,7 +35,7 @@ type githubClient interface {
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(_ *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The jira-linker plugin tries to detect JIRA references in PR titles and automatically adds a link to the ticket and a label",


### PR DESCRIPTION
Our internally-developed plugin required a couple of tweaks to build with the most recent Prow from upstream, so I've fixed that.

I also fixed up our internal build script to address a couple of small changes (eg overriding the new `EDGE_PROW_REPO` env var so we don't try to push to K8S' GCR) and to address some other minor build issues (eg the repo defines a `.bazelversion` but not a `tools/bazel` script, so we need to try to use `bazelisk` where possible to ensure we're building with the right version of Bazel).