### PR TITLE
Add needs-rebase to the io build script

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -57,6 +57,7 @@ prow_push(
         ],
         targets = {
             "ghproxy": "//ghproxy:image",
+            "needs-rebase": "//prow/external-plugins/needs-rebase:image",
         },
     ),
 )


### PR DESCRIPTION
I've published this image from this commit.  We now have a copy of `needs-rebase` at eu.gcr.io/windy-oxide-102215/needs-rebase:v20200422-fb8f6aa51