### PR TITLE
ENG-3189: Untangle GitHub's wicked web of mergeability lies.

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3171,13 +3171,7 @@ func (c *client) IsMergeable(org, repo string, number int, SHA string) (bool, er
 		if pr.Mergable != nil {
 			// In certain cases, the mergeable field is lying.
 			switch pr.MergeableState {
-			case MergeableStateBehind:
-				fallthrough
-			case MergeableStateBlocked:
-				fallthrough
-			case MergeableStateDraft:
-				fallthrough
-			case MergeableStateUnknown:
+			case MergeableStateBehind, MergeableStateBlocked, MergeableStateDraft, MergeableStateUnknown:
 				return false, fmt.Errorf("pull request is in unmergeable state %v", pr.MergeableState)
 			default:
 				return *pr.Mergable, nil

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -218,52 +218,48 @@ func TestIsMember(t *testing.T) {
 }
 
 func TestIsMergeable(t *testing.T) {
-	testCases := []struct {
-		name           string
+	type testCase struct {
 		mergeableState MergeableState
 		expectedResult bool
 		isErrExpected  bool
-	}{
-		{
-			name:           "should be true when MergeableState is clean",
-			mergeableState: MergeableStateClean,
-			expectedResult: true,
-			isErrExpected:  false,
-		},
-		{
-			name:           "should be true when MergeableState is unstable",
-			mergeableState: MergeableStateUnstable,
-			expectedResult: true,
-			isErrExpected:  false,
-		},
-		{
-			name:           "should be false when MergeableState is behind",
-			mergeableState: MergeableStateBehind,
-			expectedResult: false,
-			isErrExpected:  true,
-		},
-		{
-			name:           "should be false when MergeableState is blocked",
-			mergeableState: MergeableStateBlocked,
-			expectedResult: false,
-			isErrExpected:  true,
-		},
-		{
-			name:           "should be false when MergeableState is draft",
-			mergeableState: MergeableStateDraft,
-			expectedResult: false,
-			isErrExpected:  true,
-		},
-		{
-			name:           "should be false when MergeableState is unknown",
-			mergeableState: MergeableStateUnknown,
-			expectedResult: false,
-			isErrExpected:  true,
-		},
 	}
+
+	testCases := make(map[string]testCase)
+	testCases["should be true when MergeableState is clean"] = testCase{
+		mergeableState: MergeableStateClean,
+		expectedResult: true,
+		isErrExpected:  false,
+	}
+	testCases["should be true when MergeableState is unstable"] = testCase{
+		mergeableState: MergeableStateUnstable,
+		expectedResult: true,
+		isErrExpected:  false,
+	}
+	testCases["should be false when MergeableState is behind"] = testCase{
+		mergeableState: MergeableStateBehind,
+		expectedResult: false,
+		isErrExpected:  true,
+	}
+	testCases["should be false when MergeableState is blocked"] = testCase{
+		mergeableState: MergeableStateBlocked,
+		expectedResult: false,
+		isErrExpected:  true,
+	}
+	testCases["should be false when MergeableState is draft"] = testCase{
+		mergeableState: MergeableStateDraft,
+		expectedResult: false,
+		isErrExpected:  true,
+	}
+	testCases["should be false when MergeableState is unknown"] = testCase{
+		mergeableState: MergeableStateUnknown,
+		expectedResult: false,
+		isErrExpected:  true,
+	}
+
 	mergable := true
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
 			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodGet {
 					t.Errorf("Bad method: %s", r.Method)

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -233,6 +233,28 @@ type PullRequestEvent struct {
 	GUID string
 }
 
+type MergeableState string
+
+const (
+	// MergeableStateBehind means the head ref is out of date.
+	// Only possible when a repo has "require branches to be up to date before merging" enabled.
+	MergeableStateBehind MergeableState = "behind"
+	// MergeableStateBlocked means the PR is not mergeable.
+	MergeableStateBlocked = "blocked"
+	// MergeableStateClean means the PR is mergeable, and all statuses are passing.
+	MergeableStateClean = "clean"
+	// MergeableStateDirty means the merge commit cannot be cleanly created.
+	MergeableStateDirty = "dirty"
+	// MergeableStateDraft means the PR is in Draft mode, and cannot be merged.
+	MergeableStateDraft = "draft"
+	// MergeableStateHasHooks means the PR is mergeable, but subject to pre-receive hooks (GitHub Enterprise only)
+	MergeableStateHasHooks = "has_hooks"
+	// MergeableStateUnknown means the state cannot currently be determined.
+	MergeableStateUnknown = "unknown"
+	// MergeableStateUnstable means the PR is mergeable, but has non-passing statuses.
+	MergeableStateUnstable = "unstable"
+)
+
 // PullRequest contains information about a PullRequest.
 type PullRequest struct {
 	ID                 int               `json:"id"`
@@ -262,6 +284,10 @@ type PullRequest struct {
 	// background job was started to compute it. When the job is complete, the response
 	// will include a non-null value for the mergeable attribute.
 	Mergable *bool `json:"mergeable,omitempty"`
+	// ref https://developer.github.com/v4/enum/mergestatestatus/
+	// This is present, but not documented for REST API responses.
+	// It is documented in the equivalent GraphQL API.
+	MergeableState MergeableState `json:"mergeable_state,omitempty"`
 	// If the PR doesn't have any milestone, `milestone` is null and is unmarshaled to nil.
 	Milestone *Milestone `json:"milestone,omitempty"`
 }


### PR DESCRIPTION
It turns out that `needs-rebase` can't always tell if a PR is actually mergeable, because GitHub's API tells lies.

The response from GetPullRequest() literally has a field called `mergeable` that is sometimes wrong (it only looks at `git merge`-ability, not GitHub-merge-ability). So now they've added another field called `mergeable_state` that's got more fine-grained detail - four of the possible states there mean "not mergeable", including the one that we care about for the SVP repo, `behind` (which means "this is technically mergeable, but this repo requires that your branch be up-to-date before merging, and this branch is not up-to-date").

The result of this change is that when `needs-rebase` [asks the Prow GitHub client if a PR is mergeable](https://code.i8e.io/github.com/improbable/k8s-test-infra/-/blob/prow/external-plugins/needs-rebase/plugin/plugin.go#L111), the client will say "No" in these cases where git might let it merge, but GitHub won't.

I added tests around this as well, and will push a container built from this branch to testing-intinf to verify that it works.

Once we merge here, I'll propose it for upstreaming as well.