### PR TITLE
needs-rebase: Don't return error on unmergeable status

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3172,7 +3172,8 @@ func (c *client) IsMergeable(org, repo string, number int, SHA string) (bool, er
 			// In certain cases, the mergeable field is lying.
 			switch pr.MergeableState {
 			case MergeableStateBehind, MergeableStateBlocked, MergeableStateDraft, MergeableStateUnknown:
-				return false, fmt.Errorf("pull request is in unmergeable state %v", pr.MergeableState)
+				c.log("IsMergeable: %v/%v:%v is in unmergeable state %q", org, repo, number, pr.MergeableState)
+				return false, nil
 			default:
 				return *pr.Mergable, nil
 			}

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -238,22 +238,22 @@ func TestIsMergeable(t *testing.T) {
 	testCases["should be false when MergeableState is behind"] = testCase{
 		mergeableState: MergeableStateBehind,
 		expectedResult: false,
-		isErrExpected:  true,
+		isErrExpected:  false,
 	}
 	testCases["should be false when MergeableState is blocked"] = testCase{
 		mergeableState: MergeableStateBlocked,
 		expectedResult: false,
-		isErrExpected:  true,
+		isErrExpected:  false,
 	}
 	testCases["should be false when MergeableState is draft"] = testCase{
 		mergeableState: MergeableStateDraft,
 		expectedResult: false,
-		isErrExpected:  true,
+		isErrExpected:  false,
 	}
 	testCases["should be false when MergeableState is unknown"] = testCase{
 		mergeableState: MergeableStateUnknown,
 		expectedResult: false,
-		isErrExpected:  true,
+		isErrExpected:  false,
 	}
 
 	mergable := true


### PR DESCRIPTION
Turns out that returning an error here prevents the plugin from calling `takeAction()`, so it never attaches labels or comments.

Instead, just log the state and return false since this isn't actually an error condition.