### PR TITLE
Fix log message formatting

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3174,9 +3174,9 @@ func (c *client) IsMergeable(org, repo string, number int, SHA string) (bool, er
 			switch pr.MergeableState {
 			case MergeableStateBehind, MergeableStateBlocked, MergeableStateDraft, MergeableStateUnknown:
 				c.logger.WithFields(logrus.Fields{
-					"repo":				fmt.Sprintf("%v/%v", org, repo),
-					"pr":      			number,
-					"mergeablestate": 	pr.MergeableState,
+					"repo":           fmt.Sprintf("%v/%v", org, repo),
+					"pr":             number,
+					"mergeablestate": pr.MergeableState,
 				}).Infof("PR is in unmergeable state.")
 				return false, nil
 			default:


### PR DESCRIPTION
Just logging cleanup.  Log messages that look like this are bad and wrong:

```
{
  "client": "github",
  "level": "info",
  "msg": "IsMergeable: %v/%v:%v is in unmergeable state %q(improbable, prow-testing-intinf-eu1-testbed, 7, behind)",
  "time": "2020-05-05T18:25:53Z"
}
```

These should now be much cleaner and more structured.