### PR TITLE
Only capture the "behind" status as unmergeable

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3172,7 +3172,7 @@ func (c *client) IsMergeable(org, repo string, number int, SHA string) (bool, er
 		if pr.Mergable != nil {
 			// In certain cases, the mergeable field is lying.
 			switch pr.MergeableState {
-			case MergeableStateBehind, MergeableStateBlocked, MergeableStateDraft, MergeableStateUnknown:
+			case MergeableStateBehind:
 				c.logger.WithFields(logrus.Fields{
 					"repo":           fmt.Sprintf("%v/%v", org, repo),
 					"pr":             number,

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -240,19 +240,19 @@ func TestIsMergeable(t *testing.T) {
 		expectedResult: false,
 		isErrExpected:  false,
 	}
-	testCases["should be false when MergeableState is blocked"] = testCase{
+	testCases["should be true when MergeableState is blocked"] = testCase{
 		mergeableState: MergeableStateBlocked,
-		expectedResult: false,
+		expectedResult: true,
 		isErrExpected:  false,
 	}
-	testCases["should be false when MergeableState is draft"] = testCase{
+	testCases["should be true when MergeableState is draft"] = testCase{
 		mergeableState: MergeableStateDraft,
-		expectedResult: false,
+		expectedResult: true,
 		isErrExpected:  false,
 	}
-	testCases["should be false when MergeableState is unknown"] = testCase{
+	testCases["should be true when MergeableState is unknown"] = testCase{
 		mergeableState: MergeableStateUnknown,
-		expectedResult: false,
+		expectedResult: true,
 		isErrExpected:  false,
 	}
 


### PR DESCRIPTION
It turns out that even though the other listed states are in fact not-mergeable, a rebase isn't going to fix them, so we don't want to report on them.

Basically, `IsMergeable()` really should be named something like `IsMergeableWithoutRequiringRebase()`.  🤷 