### PR TITLE
Update test container

### DIFF
--- a/.buildkite/dockerized_tests/Dockerfile
+++ b/.buildkite/dockerized_tests/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get -qq update && \
     openjdk-8-jdk \
     patch \
     python \
+    python3 \
     ssh \
     unzip \
     xz-utils \

--- a/.buildkite/dockerized_tests/Dockerfile
+++ b/.buildkite/dockerized_tests/Dockerfile
@@ -16,14 +16,10 @@ RUN apt-get -qq update && \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the requested version of bazel and stick it in the right place so that the tools/bazel script doesn't re-download the same version.
-ENV BAZEL_VERSION="0.27.0"
-RUN export BAZEL_INSTALL_DIR="/home/user/.bazel_installations/${BAZEL_VERSION}" \
-    && curl -LSs -o /tmp/bazel.deb https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb \
-    && dpkg -i /tmp/bazel.deb \
-    && rm /tmp/bazel.deb \
-    && mkdir -p ${BAZEL_INSTALL_DIR}/bin \
-    && ln -s /usr/bin/bazel-real ${BAZEL_INSTALL_DIR}/bin/bazel
+# Install bazelisk on the path as Bazel so we don't need to explicitly keep Bazel up to date.
+ENV BAZELISK_VERSION="1.4.0"
+RUN curl -LSs -o /usr/local/bin/bazel "https://github.com/bazelbuild/bazelisk/releases/download/v${BAZEL_VERSION}/bazelisk-linux-amd64" \
+    && chmod +x /usr/local/bin/bazel
 
 RUN mkdir /bazel_cache && chmod -R 777 /bazel_cache
 

--- a/.buildkite/dockerized_tests/Dockerfile
+++ b/.buildkite/dockerized_tests/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -qq update && \
 
 # Install bazelisk on the path as Bazel so we don't need to explicitly keep Bazel up to date.
 ENV BAZELISK_VERSION="1.4.0"
-RUN curl -LSs -o /usr/local/bin/bazel "https://github.com/bazelbuild/bazelisk/releases/download/v${BAZEL_VERSION}/bazelisk-linux-amd64" \
+RUN curl -LSs -o /usr/local/bin/bazel "https://github.com/bazelbuild/bazelisk/releases/download/v${BAZELISK_VERSION}/bazelisk-linux-amd64" \
     && chmod +x /usr/local/bin/bazel
 
 RUN mkdir /bazel_cache && chmod -R 777 /bazel_cache

--- a/.buildkite/premerge.definition.yaml
+++ b/.buildkite/premerge.definition.yaml
@@ -2,11 +2,9 @@
 agent_queue_id: trigger-pipelines
 description: Premerge testing for Prow
 github:
-  default_branch: improbable2
+  default_branch: improbable
 teams:
 - name: Everyone
   permission: BUILD_AND_READ
 - name: eng-foundation/eng-velocity
-  permission: MANAGE_BUILD_AND_READ
-- name: infra/ev
   permission: MANAGE_BUILD_AND_READ

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -15,7 +15,7 @@ linux_builders: &linux_builders
     - "environment=production"
     - "permission_set=builder"
     - "platform=linux"
-    - "queue=${CI_LINUX_BUILDER_QUEUE:-v3-1564411674-9c5746811d9f2beb-------z}"
+    - "queue=${CI_LINUX_BUILDER_QUEUE:-v4-20-05-21-134527-bk11577-85e05f62}"
     - "scaler_version=2"
 
 steps:

--- a/prow/repoowners/endpoint_test.go
+++ b/prow/repoowners/endpoint_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"testing"
+
+	"k8s.io/test-infra/prow/git/localgit"
 )
 
 // TestEndpointSuccess tests the handling of normal input by the owners endpoint.
@@ -96,7 +98,7 @@ func TestEndpointSuccess(t *testing.T) {
 		},
 	}
 
-	client, cleanup, initErr := getTestClient(testFiles, true, false, true, false, nil, nil, nil, nil)
+	client, cleanup, initErr := getTestClient(testFiles, true, false, true, false, nil, nil, nil, nil, localgit.New)
 	switch {
 	case initErr != nil:
 		t.Fatalf("Error creating test client: %v.", initErr)
@@ -184,7 +186,7 @@ func TestEndPointRegex(t *testing.T) {
 		},
 	}
 
-	client, cleanup, initErr := getTestClient(testFiles, true, false, true, false, nil, nil, nil, nil)
+	client, cleanup, initErr := getTestClient(testFiles, true, false, true, false, nil, nil, nil, nil, localgit.New)
 	switch {
 	case initErr != nil:
 		t.Fatalf("Error creating test client: %v.", initErr)
@@ -241,7 +243,7 @@ func TestEndpointCorrupted(t *testing.T) {
 		},
 	}
 
-	client, cleanup, initErr := getTestClient(testFiles, true, false, true, false, nil, nil, nil, nil)
+	client, cleanup, initErr := getTestClient(testFiles, true, false, true, false, nil, nil, nil, nil, localgit.New)
 	switch {
 	case initErr != nil:
 		t.Fatalf("Error creating test client: %v.", initErr)


### PR DESCRIPTION
I noticed that my PRs on our prow fork weren't getting tested because our test container was using a very old version of Bazel that no longer works.

So I swapped out Bazel for Bazelisk on the container so we don't need to worry about keeping this one up to date.  I didn't bother pre-caching the Bazel 2.2.0 binary on the image because we run this infrequently enough that it's not really necessary.

I also fixed the incorrect default branch in the definition YAML and brought the queue up to date with platform as of today.

And finally, a test in one of our internal-only additions was legitimately broken, so I fixed it.

I've got another PR with some cleanups I'm going to open tomorrow (fix up our bazel config to use the remote cache and reduce the log spam, and move all of our internal stuff into a single, contained directory/BUILD file to reduce the risk of conflicts).