### PR TITLE
ENG-817: Add another container to publish

### DIFF
--- a/improbable/BUILD.bazel
+++ b/improbable/BUILD.bazel
@@ -54,6 +54,7 @@ prow_push(
         ],
         targets = {
             "ghproxy": "//ghproxy:image",
+            "label_sync": "//label_sync:image",
             "needs-rebase": "//prow/external-plugins/needs-rebase:image",
         },
     ),


### PR DESCRIPTION
This is for automating the `label_sync` runs.