### PR TITLE
Do not attempt synchronisation on repos without permissions

### DIFF
--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -336,6 +336,12 @@ func loadRepos(org string, gc client) ([]string, error) {
 		if r.Private && github.SecurityForkNameRE.MatchString(r.Name) {
 			continue
 		}
+		// IMPROBABLE - BEGIN
+		// Fixup as we do not want to try and fail synchronising repositories where we don't have admin access.
+		if !r.Permissions.Admin {
+			continue
+		}
+		// IMPROBABLE - END
 		rl = append(rl, r.Name)
 	}
 	return rl, nil


### PR DESCRIPTION
As the prow bot does not have admin permissions by default yet on all repositories it can encounter repositories where it does not have appropriate access. In the existing logic this results in a hard fail which we explicitly do not want. This PR ensures that labelsync will never even attempt to work on repositories it does not have admin-rights over.