### PR TITLE
add server override support for jira-linker

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -527,6 +527,12 @@ type Welcome struct {
 // JiraLinker is the config for the jira-linker plugin
 type JiraLinker struct {
 	JiraBaseUrl string `json:"jira_base_url"`
+	JiraOverrides   []JiraOverrides
+}
+
+type JiraOverrides struct {
+	JiraUrl string `json:"jira_url,omitempty"`
+	Repo       string `json:"repo,omitempty"`
 }
 
 // Dco is config for the DCO (https://developercertificate.org/) checker plugin.

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -526,13 +526,13 @@ type Welcome struct {
 
 // JiraLinker is the config for the jira-linker plugin
 type JiraLinker struct {
-	JiraBaseUrl string `json:"jira_base_url"`
-	JiraOverrides   []JiraOverrides
+	JiraBaseUrl   string          `json:"jira_base_url"`
+	JiraOverrides []JiraOverrides `json:"overrides"`
 }
 
 type JiraOverrides struct {
-	JiraUrl string `json:"jira_url,omitempty"`
-	Repo       string `json:"repo,omitempty"`
+	JiraUrl string   `json:"jira_url,omitempty"`
+	Repos   []string `json:"repos,omitempty"`
 }
 
 // Dco is config for the DCO (https://developercertificate.org/) checker plugin.

--- a/prow/plugins/jira-linker/jira-linker.go
+++ b/prow/plugins/jira-linker/jira-linker.go
@@ -113,12 +113,11 @@ func handle(gc githubClient, log *logrus.Entry, config plugins.JiraLinker, event
 
 func findJiraUrl(config plugins.JiraLinker, repo string) string {
 	jiraServerURL := config.JiraBaseUrl
-out:
 	for _, v := range config.JiraOverrides {
 		for _, x := range v.Repos {
 			if x == repo {
 				jiraServerURL = v.JiraUrl
-				break out
+				return jiraServerURL
 			}
 		}
 	}

--- a/prow/plugins/jira-linker/jira-linker.go
+++ b/prow/plugins/jira-linker/jira-linker.go
@@ -88,10 +88,13 @@ func handle(gc githubClient, log *logrus.Entry, config plugins.JiraLinker, event
 
 		if !hasLabel {
 			jiraServerURL := config.JiraBaseUrl
+			out:
 			for _, v := range config.JiraOverrides{
-				if v.Repo == repo {
-					jiraServerURL = v.JiraUrl
-					break
+				for _, x := range v.Repos {
+					if x == repo {
+						jiraServerURL = v.JiraUrl
+						break out
+					}
 				}
 			}
 			gc.CreateComment(org, repo, event.Number, commentForTicket(jiraLink(jiraServerURL, ticketName)))

--- a/prow/plugins/jira-linker/jira-linker.go
+++ b/prow/plugins/jira-linker/jira-linker.go
@@ -87,16 +87,7 @@ func handle(gc githubClient, log *logrus.Entry, config plugins.JiraLinker, event
 		}
 
 		if !hasLabel {
-			jiraServerURL := config.JiraBaseUrl
-			out:
-			for _, v := range config.JiraOverrides{
-				for _, x := range v.Repos {
-					if x == repo {
-						jiraServerURL = v.JiraUrl
-						break out
-					}
-				}
-			}
+			jiraServerURL := findJiraUrl(config, repo)
 			gc.CreateComment(org, repo, event.Number, commentForTicket(jiraLink(jiraServerURL, ticketName)))
 			gc.AddLabel(org, repo, event.Number, jiraLabel(jiraTeamName))
 		}
@@ -118,6 +109,20 @@ func handle(gc githubClient, log *logrus.Entry, config plugins.JiraLinker, event
 	}
 
 	return nil
+}
+
+func findJiraUrl(config plugins.JiraLinker, repo string) string {
+	jiraServerURL := config.JiraBaseUrl
+out:
+	for _, v := range config.JiraOverrides {
+		for _, x := range v.Repos {
+			if x == repo {
+				jiraServerURL = v.JiraUrl
+				break out
+			}
+		}
+	}
+	return jiraServerURL
 }
 
 // Returns if found, and if so respectively the ticket type (e.g. ENG) and the ticket ref (e.g. ENG-23)

--- a/prow/plugins/jira-linker/jira-linker.go
+++ b/prow/plugins/jira-linker/jira-linker.go
@@ -87,7 +87,14 @@ func handle(gc githubClient, log *logrus.Entry, config plugins.JiraLinker, event
 		}
 
 		if !hasLabel {
-			gc.CreateComment(org, repo, event.Number, commentForTicket(jiraLink(config.JiraBaseUrl, ticketName)))
+			jiraServerURL := config.JiraBaseUrl
+			for _, v := range config.JiraOverrides{
+				if v.Repo == repo {
+					jiraServerURL = v.JiraUrl
+					break
+				}
+			}
+			gc.CreateComment(org, repo, event.Number, commentForTicket(jiraLink(jiraServerURL, ticketName)))
 			gc.AddLabel(org, repo, event.Number, jiraLabel(jiraTeamName))
 		}
 	} else {

--- a/prow/plugins/jira-linker/jira-linker_test.go
+++ b/prow/plugins/jira-linker/jira-linker_test.go
@@ -187,3 +187,41 @@ func TestJiraTicketRef(t *testing.T) {
 		}
 	}
 }
+
+func TestFindJiraUrl(t *testing.T) {
+	config := plugins.JiraLinker{
+		JiraBaseUrl: "https://base.atlassian.net",
+		JiraOverrides: []plugins.JiraOverrides{
+			{
+				JiraUrl: "https://defence.atlassian.net",
+				Repos:   []string{"defence-repo-1", "defence-repo-2"},
+			},
+			{
+				JiraUrl: "https://other.atlassian.net",
+				Repos:   []string{"other-repo-1", "other-repo-2"},
+			},
+		},
+	}
+	for _, test := range []struct{
+		repo string
+		expectedURL	string
+	}{
+		{
+			repo: "an-improbable-repo",
+			expectedURL: "https://base.atlassian.net",
+		},
+		{
+			repo: "defence-repo-1",
+			expectedURL: "https://defence.atlassian.net",
+		},
+		{
+			repo: "other-repo-2",
+			expectedURL: "https://other.atlassian.net",
+		},
+	} {
+		foundJiraServer := findJiraUrl(config, test.repo)
+		if foundJiraServer != test.expectedURL {
+			t.Errorf("Unexpected URL returned (got #{foundJiraServer}, expected #{test.expectedURL}")
+		}
+	}
+}

--- a/prow/plugins/jira-linker/jira-linker_test.go
+++ b/prow/plugins/jira-linker/jira-linker_test.go
@@ -221,7 +221,7 @@ func TestFindJiraUrl(t *testing.T) {
 	} {
 		foundJiraServer := findJiraUrl(config, test.repo)
 		if foundJiraServer != test.expectedURL {
-			t.Errorf("Unexpected URL returned (got %q, expected %q",foundJiraServer,  test.expectedURL)
+			t.Errorf("Unexpected URL returned (got %q, expected %q)",foundJiraServer,  test.expectedURL)
 		}
 	}
 }

--- a/prow/plugins/jira-linker/jira-linker_test.go
+++ b/prow/plugins/jira-linker/jira-linker_test.go
@@ -221,7 +221,7 @@ func TestFindJiraUrl(t *testing.T) {
 	} {
 		foundJiraServer := findJiraUrl(config, test.repo)
 		if foundJiraServer != test.expectedURL {
-			t.Errorf("Unexpected URL returned (got #{foundJiraServer}, expected #{test.expectedURL}")
+			t.Errorf("Unexpected URL returned (got %q, expected %q",foundJiraServer,  test.expectedURL)
 		}
 	}
 }


### PR DESCRIPTION
The following changes should allow customers to add a jira-server override to our global `jira-linker` config.


Example config:
```
jira_linker:
  jira_base_url: https://improbableio.atlassian.net
  - overrides:
  	- jira_url: https://improbabledefence.atlassian.net
      repos:
		- defence-repo-a	# we should only use the repo_name as to not confuse users into thinking that prow is configured for other gh orgs
		- defence-repo-b
```